### PR TITLE
Fix tina require

### DIFF
--- a/lib/init/index.js
+++ b/lib/init/index.js
@@ -11,7 +11,7 @@ window.settings  = settings;
 var assetLoader  = require('assetLoader');
 var AudioManager = require('audio-manager');
 var Texture      = require('Texture');
-var TINA         = require('TINA');
+var TINA         = require('tina');
 var EventEmitter = require('EventEmitter');
 var Map          = require('Map');
 


### PR DESCRIPTION
Without this, opening a browser window to a fresh pixelbox project shows
this error:

    Error: Cannot find module 'TINA' from '/mnt/futokoro/fiddle/ld39/node_modules'

Seems Tina just need to be required lower case to fix it. 

I guess this was caused by a change in Tina at some point? -POLM